### PR TITLE
chore(workflows): remove custom event name 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,6 @@ name: Lint
 on:
   workflow_dispatch:
   pull_request:
-  # Custom event name to run this action locally
-  _lint:
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ name: Test
 on:
   workflow_dispatch:
   pull_request:
-  # Custom event name to run this action locally
-  _test:
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix "not a valid event name" error