### PR TITLE
chore: update package locks

### DIFF
--- a/packages/cisco/analytics/package-lock.json
+++ b/packages/cisco/analytics/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@cisco/analytics",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cisco/core": "^0.5.2",
+        "@cisco/core": "^0.5.3",
         "snake-case": "^3.0.4"
       },
       "devDependencies": {
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@cisco/core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.2.tgz",
-      "integrity": "sha512-KXRZdHVb1dBHk59pqSnh9Dk7PIijR6WGvALZXBV0EDpnYgt6PoZZ2qK5iT6i5wXwV/xUD+yjaP9XXJmRTiqn8w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-s8FL68nwNgKGvdVb5xwnNnIrBICC5wnJ+yAv8Cm3QDwEmIspALE+i1v5F0jwlFLLsM99CoESJyLig3scyf+xOw==",
       "dependencies": {
         "force-boolean": "^1.2.0",
         "normalize-url": "5.3.1"
@@ -2412,9 +2412,9 @@
       }
     },
     "@cisco/core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.2.tgz",
-      "integrity": "sha512-KXRZdHVb1dBHk59pqSnh9Dk7PIijR6WGvALZXBV0EDpnYgt6PoZZ2qK5iT6i5wXwV/xUD+yjaP9XXJmRTiqn8w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-s8FL68nwNgKGvdVb5xwnNnIrBICC5wnJ+yAv8Cm3QDwEmIspALE+i1v5F0jwlFLLsM99CoESJyLig3scyf+xOw==",
       "requires": {
         "force-boolean": "^1.2.0",
         "normalize-url": "5.3.1"

--- a/packages/cisco/bot-commands/package-lock.json
+++ b/packages/cisco/bot-commands/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@cisco/bot-commands",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cisco/analytics": "^0.5.2",
+        "@cisco/analytics": "^0.5.3",
         "@giphy/js-fetch-api": "^2.4.0",
         "axios": "^0.21.4",
         "jest": "^27.5.1"
@@ -561,18 +561,18 @@
       "license": "MIT"
     },
     "node_modules/@cisco/analytics": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.2.tgz",
-      "integrity": "sha512-7LN2PFjiLpOtFKGiwSblZFf33K62gr118kfJEIsWDokSYiSCnZVFWx6Uz2b3Pc3S+p/ZEFmKOZl5w1nSc0aUVw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.3.tgz",
+      "integrity": "sha512-E0/t9aSC5WPaGEGuxs0e6Q+DV2G3yqnvAuxm1jQ5bwjPU3rKMz6ZVVPw/lBw9ee85eJlB02v7TIjiCZ63/EClw==",
       "dependencies": {
-        "@cisco/core": "^0.5.2",
+        "@cisco/core": "^0.5.3",
         "snake-case": "^3.0.4"
       }
     },
     "node_modules/@cisco/core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.2.tgz",
-      "integrity": "sha512-KXRZdHVb1dBHk59pqSnh9Dk7PIijR6WGvALZXBV0EDpnYgt6PoZZ2qK5iT6i5wXwV/xUD+yjaP9XXJmRTiqn8w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-s8FL68nwNgKGvdVb5xwnNnIrBICC5wnJ+yAv8Cm3QDwEmIspALE+i1v5F0jwlFLLsM99CoESJyLig3scyf+xOw==",
       "dependencies": {
         "force-boolean": "^1.2.0",
         "normalize-url": "5.3.1"
@@ -6326,18 +6326,18 @@
       "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk="
     },
     "@cisco/analytics": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.2.tgz",
-      "integrity": "sha512-7LN2PFjiLpOtFKGiwSblZFf33K62gr118kfJEIsWDokSYiSCnZVFWx6Uz2b3Pc3S+p/ZEFmKOZl5w1nSc0aUVw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.3.tgz",
+      "integrity": "sha512-E0/t9aSC5WPaGEGuxs0e6Q+DV2G3yqnvAuxm1jQ5bwjPU3rKMz6ZVVPw/lBw9ee85eJlB02v7TIjiCZ63/EClw==",
       "requires": {
-        "@cisco/core": "^0.5.2",
+        "@cisco/core": "^0.5.3",
         "snake-case": "^3.0.4"
       }
     },
     "@cisco/core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.2.tgz",
-      "integrity": "sha512-KXRZdHVb1dBHk59pqSnh9Dk7PIijR6WGvALZXBV0EDpnYgt6PoZZ2qK5iT6i5wXwV/xUD+yjaP9XXJmRTiqn8w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-s8FL68nwNgKGvdVb5xwnNnIrBICC5wnJ+yAv8Cm3QDwEmIspALE+i1v5F0jwlFLLsM99CoESJyLig3scyf+xOw==",
       "requires": {
         "force-boolean": "^1.2.0",
         "normalize-url": "5.3.1"

--- a/packages/cisco/bot-factory/package-lock.json
+++ b/packages/cisco/bot-factory/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@cisco/bot-factory",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cisco/bot-middleware": "^0.9.2",
+        "@cisco/bot-middleware": "^0.9.3",
         "botbuilder-adapter-webex": "^1.0.9",
         "botkit": "^4.10.0"
       },
@@ -2588,21 +2588,21 @@
       }
     },
     "node_modules/@cisco/analytics": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.2.tgz",
-      "integrity": "sha512-7LN2PFjiLpOtFKGiwSblZFf33K62gr118kfJEIsWDokSYiSCnZVFWx6Uz2b3Pc3S+p/ZEFmKOZl5w1nSc0aUVw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.3.tgz",
+      "integrity": "sha512-E0/t9aSC5WPaGEGuxs0e6Q+DV2G3yqnvAuxm1jQ5bwjPU3rKMz6ZVVPw/lBw9ee85eJlB02v7TIjiCZ63/EClw==",
       "dependencies": {
-        "@cisco/core": "^0.5.2",
+        "@cisco/core": "^0.5.3",
         "snake-case": "^3.0.4"
       }
     },
     "node_modules/@cisco/bot-middleware": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@cisco/bot-middleware/-/bot-middleware-0.9.2.tgz",
-      "integrity": "sha512-fCwHuP96+zYy5rmGkt4iZc3ZnZRuRejYZK1xgQvfWARS41KrKJkVEtg8jRNU7AbExqITBFBvTb8RXY+vq+ofjQ==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@cisco/bot-middleware/-/bot-middleware-0.9.3.tgz",
+      "integrity": "sha512-L2cHFqlIMuHCFWNsb/JiePP+YU4ZSYwb205qEmwvzJwes1ZIzpiOEa34Gq1IeuxZDvMzYn7onh/f2BFFtVx48g==",
       "dependencies": {
-        "@cisco/analytics": "^0.5.2",
-        "@cisco/google": "^0.4.2",
+        "@cisco/analytics": "^0.5.3",
+        "@cisco/google": "^0.4.3",
         "@google-cloud/dialogflow": "^4.4.0",
         "@humanwhocodes/env": "^2.2.0",
         "axios": "^0.21.4",
@@ -2621,18 +2621,18 @@
       }
     },
     "node_modules/@cisco/core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.2.tgz",
-      "integrity": "sha512-KXRZdHVb1dBHk59pqSnh9Dk7PIijR6WGvALZXBV0EDpnYgt6PoZZ2qK5iT6i5wXwV/xUD+yjaP9XXJmRTiqn8w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-s8FL68nwNgKGvdVb5xwnNnIrBICC5wnJ+yAv8Cm3QDwEmIspALE+i1v5F0jwlFLLsM99CoESJyLig3scyf+xOw==",
       "dependencies": {
         "force-boolean": "^1.2.0",
         "normalize-url": "5.3.1"
       }
     },
     "node_modules/@cisco/google": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cisco/google/-/google-0.4.2.tgz",
-      "integrity": "sha512-B8iQaRbcOHMg4S5ZYXVWEcBXXESdZx9xX+VMM5UxtaCQFNN0pQ+qDqKwuXp7LBN7de3XEWAzesNZ3yG14ThDqg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@cisco/google/-/google-0.4.3.tgz",
+      "integrity": "sha512-DEd/qD+gNsvH5Qz5PnXpADjIJwrMiEksbcD0QcJI9PLzGCi0lbdLw2h+QoK8R6umoUHTmYHDrGWAWNElCY7d5w==",
       "dependencies": {
         "@humanwhocodes/env": "^2.2.0",
         "google-auth-library": "^7.10.0"
@@ -20961,21 +20961,21 @@
       }
     },
     "@cisco/analytics": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.2.tgz",
-      "integrity": "sha512-7LN2PFjiLpOtFKGiwSblZFf33K62gr118kfJEIsWDokSYiSCnZVFWx6Uz2b3Pc3S+p/ZEFmKOZl5w1nSc0aUVw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.3.tgz",
+      "integrity": "sha512-E0/t9aSC5WPaGEGuxs0e6Q+DV2G3yqnvAuxm1jQ5bwjPU3rKMz6ZVVPw/lBw9ee85eJlB02v7TIjiCZ63/EClw==",
       "requires": {
-        "@cisco/core": "^0.5.2",
+        "@cisco/core": "^0.5.3",
         "snake-case": "^3.0.4"
       }
     },
     "@cisco/bot-middleware": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@cisco/bot-middleware/-/bot-middleware-0.9.2.tgz",
-      "integrity": "sha512-fCwHuP96+zYy5rmGkt4iZc3ZnZRuRejYZK1xgQvfWARS41KrKJkVEtg8jRNU7AbExqITBFBvTb8RXY+vq+ofjQ==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@cisco/bot-middleware/-/bot-middleware-0.9.3.tgz",
+      "integrity": "sha512-L2cHFqlIMuHCFWNsb/JiePP+YU4ZSYwb205qEmwvzJwes1ZIzpiOEa34Gq1IeuxZDvMzYn7onh/f2BFFtVx48g==",
       "requires": {
-        "@cisco/analytics": "^0.5.2",
-        "@cisco/google": "^0.4.2",
+        "@cisco/analytics": "^0.5.3",
+        "@cisco/google": "^0.4.3",
         "@google-cloud/dialogflow": "^4.4.0",
         "@humanwhocodes/env": "^2.2.0",
         "axios": "^0.21.4",
@@ -20995,18 +20995,18 @@
       }
     },
     "@cisco/core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.2.tgz",
-      "integrity": "sha512-KXRZdHVb1dBHk59pqSnh9Dk7PIijR6WGvALZXBV0EDpnYgt6PoZZ2qK5iT6i5wXwV/xUD+yjaP9XXJmRTiqn8w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-s8FL68nwNgKGvdVb5xwnNnIrBICC5wnJ+yAv8Cm3QDwEmIspALE+i1v5F0jwlFLLsM99CoESJyLig3scyf+xOw==",
       "requires": {
         "force-boolean": "^1.2.0",
         "normalize-url": "5.3.1"
       }
     },
     "@cisco/google": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cisco/google/-/google-0.4.2.tgz",
-      "integrity": "sha512-B8iQaRbcOHMg4S5ZYXVWEcBXXESdZx9xX+VMM5UxtaCQFNN0pQ+qDqKwuXp7LBN7de3XEWAzesNZ3yG14ThDqg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@cisco/google/-/google-0.4.3.tgz",
+      "integrity": "sha512-DEd/qD+gNsvH5Qz5PnXpADjIJwrMiEksbcD0QcJI9PLzGCi0lbdLw2h+QoK8R6umoUHTmYHDrGWAWNElCY7d5w==",
       "requires": {
         "@humanwhocodes/env": "^2.2.0",
         "google-auth-library": "^7.10.0"

--- a/packages/cisco/bot-middleware/package-lock.json
+++ b/packages/cisco/bot-middleware/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@cisco/bot-middleware",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cisco/analytics": "^0.5.2",
-        "@cisco/google": "^0.4.2",
+        "@cisco/analytics": "^0.5.3",
+        "@cisco/google": "^0.4.3",
         "@google-cloud/dialogflow": "^4.4.0",
         "@humanwhocodes/env": "^2.2.0",
         "axios": "^0.21.4",
@@ -61,27 +61,27 @@
       }
     },
     "node_modules/@cisco/analytics": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.2.tgz",
-      "integrity": "sha512-7LN2PFjiLpOtFKGiwSblZFf33K62gr118kfJEIsWDokSYiSCnZVFWx6Uz2b3Pc3S+p/ZEFmKOZl5w1nSc0aUVw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.3.tgz",
+      "integrity": "sha512-E0/t9aSC5WPaGEGuxs0e6Q+DV2G3yqnvAuxm1jQ5bwjPU3rKMz6ZVVPw/lBw9ee85eJlB02v7TIjiCZ63/EClw==",
       "dependencies": {
-        "@cisco/core": "^0.5.2",
+        "@cisco/core": "^0.5.3",
         "snake-case": "^3.0.4"
       }
     },
     "node_modules/@cisco/core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.2.tgz",
-      "integrity": "sha512-KXRZdHVb1dBHk59pqSnh9Dk7PIijR6WGvALZXBV0EDpnYgt6PoZZ2qK5iT6i5wXwV/xUD+yjaP9XXJmRTiqn8w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-s8FL68nwNgKGvdVb5xwnNnIrBICC5wnJ+yAv8Cm3QDwEmIspALE+i1v5F0jwlFLLsM99CoESJyLig3scyf+xOw==",
       "dependencies": {
         "force-boolean": "^1.2.0",
         "normalize-url": "5.3.1"
       }
     },
     "node_modules/@cisco/google": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cisco/google/-/google-0.4.2.tgz",
-      "integrity": "sha512-B8iQaRbcOHMg4S5ZYXVWEcBXXESdZx9xX+VMM5UxtaCQFNN0pQ+qDqKwuXp7LBN7de3XEWAzesNZ3yG14ThDqg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@cisco/google/-/google-0.4.3.tgz",
+      "integrity": "sha512-DEd/qD+gNsvH5Qz5PnXpADjIJwrMiEksbcD0QcJI9PLzGCi0lbdLw2h+QoK8R6umoUHTmYHDrGWAWNElCY7d5w==",
       "dependencies": {
         "@humanwhocodes/env": "^2.2.0",
         "google-auth-library": "^7.10.0"
@@ -3038,27 +3038,27 @@
       }
     },
     "@cisco/analytics": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.2.tgz",
-      "integrity": "sha512-7LN2PFjiLpOtFKGiwSblZFf33K62gr118kfJEIsWDokSYiSCnZVFWx6Uz2b3Pc3S+p/ZEFmKOZl5w1nSc0aUVw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/analytics/-/analytics-0.5.3.tgz",
+      "integrity": "sha512-E0/t9aSC5WPaGEGuxs0e6Q+DV2G3yqnvAuxm1jQ5bwjPU3rKMz6ZVVPw/lBw9ee85eJlB02v7TIjiCZ63/EClw==",
       "requires": {
-        "@cisco/core": "^0.5.2",
+        "@cisco/core": "^0.5.3",
         "snake-case": "^3.0.4"
       }
     },
     "@cisco/core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.2.tgz",
-      "integrity": "sha512-KXRZdHVb1dBHk59pqSnh9Dk7PIijR6WGvALZXBV0EDpnYgt6PoZZ2qK5iT6i5wXwV/xUD+yjaP9XXJmRTiqn8w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@cisco/core/-/core-0.5.3.tgz",
+      "integrity": "sha512-s8FL68nwNgKGvdVb5xwnNnIrBICC5wnJ+yAv8Cm3QDwEmIspALE+i1v5F0jwlFLLsM99CoESJyLig3scyf+xOw==",
       "requires": {
         "force-boolean": "^1.2.0",
         "normalize-url": "5.3.1"
       }
     },
     "@cisco/google": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cisco/google/-/google-0.4.2.tgz",
-      "integrity": "sha512-B8iQaRbcOHMg4S5ZYXVWEcBXXESdZx9xX+VMM5UxtaCQFNN0pQ+qDqKwuXp7LBN7de3XEWAzesNZ3yG14ThDqg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@cisco/google/-/google-0.4.3.tgz",
+      "integrity": "sha512-DEd/qD+gNsvH5Qz5PnXpADjIJwrMiEksbcD0QcJI9PLzGCi0lbdLw2h+QoK8R6umoUHTmYHDrGWAWNElCY7d5w==",
       "requires": {
         "@humanwhocodes/env": "^2.2.0",
         "google-auth-library": "^7.10.0"

--- a/packages/cisco/cards/package-lock.json
+++ b/packages/cisco/cards/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@cisco/cards",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "Apache-2.0",
       "dependencies": {
         "moment": "^2.29.1"

--- a/packages/cisco/core/package-lock.json
+++ b/packages/cisco/core/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@cisco/core",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "force-boolean": "^1.2.0",

--- a/packages/cisco/digital-garden/package-lock.json
+++ b/packages/cisco/digital-garden/package-lock.json
@@ -6,9 +6,9 @@
   "packages": {
     "": {
       "name": "@cisco/digital-garden",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
-        "@cisco/docs-docusaurus": "^0.2.2",
+        "@cisco/docs-docusaurus": "^0.2.3",
         "@docusaurus/core": "^2.0.0-beta.18",
         "@docusaurus/preset-classic": "^2.0.0-beta.18",
         "@humanwhocodes/env": "^2.2.0",
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@cisco/docs-docusaurus": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@cisco/docs-docusaurus/-/docs-docusaurus-0.2.2.tgz",
-      "integrity": "sha512-TBxxJEB0J3apXFqjMyEea/6XsK8sir/j5xc4jK+2P+5PoL1DMuzYOXnkXwlqpAVaI4owS24QQSm5mSxH/jeU3A=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@cisco/docs-docusaurus/-/docs-docusaurus-0.2.3.tgz",
+      "integrity": "sha512-WeuZkArrw3fTQ6fjICDSRvdmAgqodz/APRU4ctvujGcCuPAqhMj7HEPfgD/hcQmGe6YtvotnaBxp5Yf/wnPyQA=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -39539,9 +39539,9 @@
       }
     },
     "@cisco/docs-docusaurus": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@cisco/docs-docusaurus/-/docs-docusaurus-0.2.2.tgz",
-      "integrity": "sha512-TBxxJEB0J3apXFqjMyEea/6XsK8sir/j5xc4jK+2P+5PoL1DMuzYOXnkXwlqpAVaI4owS24QQSm5mSxH/jeU3A=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@cisco/docs-docusaurus/-/docs-docusaurus-0.2.3.tgz",
+      "integrity": "sha512-WeuZkArrw3fTQ6fjICDSRvdmAgqodz/APRU4ctvujGcCuPAqhMj7HEPfgD/hcQmGe6YtvotnaBxp5Yf/wnPyQA=="
     },
     "@colors/colors": {
       "version": "1.5.0",

--- a/packages/cisco/docs-docusaurus/package-lock.json
+++ b/packages/cisco/docs-docusaurus/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@cisco/docs-docusaurus",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.17.8",

--- a/packages/cisco/google/package-lock.json
+++ b/packages/cisco/google/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@cisco/google",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/env": "^2.2.0",

--- a/packages/cisco/releases/package-lock.json
+++ b/packages/cisco/releases/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@cisco/releases",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/env": "^2.2.0",

--- a/packages/cisco/salesforce/package-lock.json
+++ b/packages/cisco/salesforce/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@cisco/salesforce",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.4",


### PR DESCRIPTION
affects: @cisco/analytics, @cisco/bot-commands, @cisco/bot-factory, @cisco/bot-middleware,
@cisco/cards, @cisco/core, @cisco/digital-garden, @cisco/docs-docusaurus, @cisco/google,
@cisco/releases, @cisco/salesforce